### PR TITLE
fix: undefined options.extId

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,9 +70,9 @@ export class MozillaAddonsAPI {
       if (!options.extId.endsWith("}")) {
         options.extId += "}"
       }
-
-      this.options.extId = options.extId
     }
+
+    this.options.extId = options.extId
   }
 
   submit = async ({ filePath, version = "1.0.0" }) => {


### PR DESCRIPTION
There is a bug in `options.extId`. If a format other than GUID is specified for `options.extId`, `this.options.extId` is undefined.

This patch fixes this.
