### PR TITLE
fix: use v4 of the Mozilla addons API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ export class MozillaAddonsAPI {
   options = {} as Options
 
   get productEndpoint() {
-    return `${baseApiUrl}/v5/addons/${encodeURIComponent(this.options.extId)}`
+    return `${baseApiUrl}/v4/addons/${encodeURIComponent(this.options.extId)}`
   }
 
   constructor(options: Options) {


### PR DESCRIPTION
## Details

This PR changes the used version of the Mozilla addons API from v5 to v4. The library uses the addons signing endpoint, which was removed from the v5 API in April ([see this PR](https://github.com/mozilla/addons-server/pull/20568)), which breaks the PlasmoHQ/bpp action for Firefox publishing ([example](https://github.com/Curetix/mailflare-extension/actions/runs/5080174335/jobs/9127239993#step:4:11)). The endpoint is still available in the v4 API.

### Code of Conduct

- [X] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [X] I agree to license this contribution under the MIT LICENSE
- [X] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID: Curetix#1794