### PR TITLE
feat: use v5 API endpoints

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -20,7 +20,7 @@ test("test upload test.zip artifact", async () => {
     version
   })
 
-  const uploadStatus = await client.getUploadStatus({ version })
+  const uploadStatus = await client.getVersion({ version })
 
-  expect(uploadStatus.guid).toBe(resp.guid)
+  expect(uploadStatus.id).toBe(resp.id)
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,7 +171,7 @@ export class MozillaAddonsAPI {
     const accessToken = await this.getAccessToken()
 
     // https://addons-server.readthedocs.io/en/latest/topics/api/addons.html#upload-create
-    const uploadEndpoint = `${baseApiUrl}/addons/upload/`
+    const uploadEndpoint = `${baseApiUrl}/v5/addons/upload/`
 
     const formData = new FormData()
     formData.append("upload", await fileFromPath(filePath))

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,7 +146,8 @@ export class MozillaAddonsAPI {
       body: formData,
       headers: {
         Authorization: `JWT ${accessToken}`
-      }
+      },
+      throwHttpErrors: false
     })
 
     if (resp.statusCode >= 400) {
@@ -180,7 +181,8 @@ export class MozillaAddonsAPI {
       body: formData,
       headers: {
         Authorization: `JWT ${accessToken}`
-      }
+      },
+      throwHttpErrors: false
     })
 
     if (resp.statusCode >= 400) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,38 @@ type StatusResponse = {
   version: string
 }
 
+type ProfileResponse = {
+  id: number
+  name: string
+  url: string
+  username: string
+  average_addon_rating: number | null
+  created: string
+  biography: string
+  has_anonymous_display_name: boolean
+  has_anonymous_username: boolean
+  homepage: string
+  is_addon_developer: boolean
+  is_artist: boolean
+  location: string
+  occupation: string
+  num_addons_listed: number
+  picture_type: string
+  picture_url: string
+  deleted: boolean
+  display_name: string
+  email: string
+  fxa_edit_email_url: string
+  last_login: string
+  last_login_ip: string
+  permissions: string[]
+  read_dev_agreement: string
+  site_status: {
+    read_only: boolean
+    notice: string | null
+  }
+}
+
 export const errorMap = {
   apiKey:
     "API Key is required. To get one: https://addons.mozilla.org/en-US/developers/addon/api/key",
@@ -123,7 +155,7 @@ export class MozillaAddonsAPI {
           Authorization: `JWT ${accessToken}`
         }
       })
-      .json<StatusResponse>()
+      .json<VersionResponse>()
   }
 
   getProfile = async () => {
@@ -137,7 +169,7 @@ export class MozillaAddonsAPI {
           Authorization: `JWT ${accessToken}`
         }
       })
-      .json<StatusResponse>()
+      .json<ProfileResponse>()
   }
 
   getAccessToken = async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,6 +126,13 @@ export class MozillaAddonsAPI {
     }
 
     this.options.extId = options.extId
+
+    if (
+      typeof options.channel === "string" &&
+      (options.channel === "listed" || options.channel === "unlisted")
+    ) {
+      this.options.channel = options.channel
+    }
   }
 
   submit = async ({ filePath, version = "1.0.0" }) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,14 @@
+export async function retry(
+  operation: () => Promise<boolean>,
+  retries: number,
+  delay: number
+): Promise<boolean> {
+  for (let i = 0; i < retries; i++) {
+    if (await operation()) {
+      return true
+    }
+    await new Promise((r) => setTimeout(r, delay))
+  }
+
+  return false
+}


### PR DESCRIPTION
## Details

Use v5 API addon submission endpoints and add proper response types.

The upload `/addons/upload/` endpoint now requires the `channel` parameter ("listed" or "unlisted"). Previously it simply assumed the value of the last version if it was not provided. I added it as a new field to `Options` so the user can configure this to their requirements (probably requires more changes elsewhere, e.g. in the schema for keys.json).

~~So far I only tested the requests with Postman, on my machine the Jest test run fails with a `RequestError: socket hang up` (timeout) for some reason.~~

### Code of Conduct

- [X] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [X] I agree to license this contribution under the MIT LICENSE
- [X] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.