### PR TITLE
fix: createVersion extId styling, upload timeout

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -120,21 +120,6 @@ export class MozillaAddonsAPI {
 
     this.options = { ...options }
 
-    // Make sure it's not an email-based extID
-    if (
-      typeof this.options.extId === "string" &&
-      this.options.extId.length > 0 &&
-      !this.options.extId.includes("@")
-    ) {
-      if (!this.options.extId.startsWith("{")) {
-        this.options.extId = "{" + options.extId
-      }
-
-      if (!this.options.extId.endsWith("}")) {
-        this.options.extId += "}"
-      }
-    }
-
     this.options.channel = options.channel || "listed"
 
     if (this.options.license === "inherit") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,8 +148,8 @@ export class MozillaAddonsAPI {
         })
         return uploadStatus.valid
       },
-      8,
-      5000
+      60,
+      10000 // 10 min timeout recommended by mozilla
     )
 
     // Wait for upload to be validated


### PR DESCRIPTION
## Changes
- Uploads were often failing due to delays on validation processing on Mozilla's side, so I increased the timeout to their recommendation [here](https://blog.mozilla.org/addons/2022/03/17/new-api-for-submitting-and-updating-add-ons/#:~:text=Uploading%20the%20add%2Don%20file)
- Removed `{}` wrapping of `extId` which appears to no longer be compatible with the v5 API because all `createVersion` requests were returning `{"detail": "Not found."}`. I also tested a url-encoded email address as the extension id and it worked as expected.